### PR TITLE
Remove re-prompt from the card emit parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ var handlers = {
         if (translation) {
             this.attributes['speechOutput'] = translation;
             this.attributes['repromtSpeech'] = this.t("SLANG_REPEAT_MESSAGE");
-            this.emit(':tellWithCard', translation, this.attributes['repromptSpeech'], cardTitle, translation);
+            this.emit(':tellWithCard', translation, cardTitle, translation);
         } else {
             var speechOutput = this.t("SLANG_NOT_FOUND_MESSAGE");
             var repromptSpeech = this.t("SLANG_NOT_FOUND_REPROMPT");


### PR DESCRIPTION
Hey Joe,

I noticed a bug with the card actions that would appear on your phone when using the app.

The ```emit``` method for the 'tellWithCard' should only take four parameters, not including the emit method name; 

```javascript
this.emit(':tellWithCard', speechOutput, cardTitle, cardContent, imageObj);
```

Gimmie a shout if you need further explanation.